### PR TITLE
Response

### DIFF
--- a/include/cmdlib/CommandFacility.hpp
+++ b/include/cmdlib/CommandFacility.hpp
@@ -66,7 +66,6 @@ public:
   virtual void run(std::atomic<bool>& end_marker) = 0;
 
   //! Feed commands from the implementation.
-
   void execute_command(cmdmeta_t meta);
 
 protected:
@@ -74,6 +73,9 @@ protected:
   virtual void completion_callback(cmdmeta_t& meta) = 0; 
 
 private:
+
+  //! The glue between commanded and completion callback
+  void handle_command(cmdmeta_t command);
 
   void executor();
 
@@ -87,9 +89,6 @@ private:
   //! Request callback function signature
   typedef std::function<void(cmdmeta_t)> CommandCallback;
   CommandCallback m_command_callback = nullptr;
-
-  //! The glue between commanded and completion callback
-  void handle_command(cmdmeta_t command);
 
   //! Single thrad is responsible to trigger tasks 
   std::atomic<bool> m_active;

--- a/include/cmdlib/CommandFacility.hpp
+++ b/include/cmdlib/CommandFacility.hpp
@@ -67,11 +67,11 @@ public:
 
   //! Feed commands from the implementation.
 
-  void executeCommand(cmdmeta_t meta);
+  void execute_command(cmdmeta_t meta);
 
 protected:
   //! Must be implemented to handling the results of the commands
-  virtual void completionCallback(cmdmeta_t& meta) = 0; 
+  virtual void completion_callback(cmdmeta_t& meta) = 0; 
 
 private:
 

--- a/include/cmdlib/CommandFacility.hpp
+++ b/include/cmdlib/CommandFacility.hpp
@@ -66,16 +66,14 @@ public:
   virtual void run(std::atomic<bool>& end_marker) = 0;
 
   //! Feed commands from the implementation.
-  void execute_command(const cmdobj_t& command);
+
+  void executeCommand(cmdmeta_t meta);
 
 protected:
   //! Must be implemented to handling the results of the commands
-  virtual void completion_callback(const std::string& result) = 0; 
+  virtual void completionCallback(cmdmeta_t& meta) = 0; 
 
 private:
-
-  //! The glue between commanded and completion callback
-  void handle_command(const cmdobj_t& command);
 
   void executor();
 
@@ -87,8 +85,11 @@ private:
   CompletionQueue m_completion_queue;
 
   //! Request callback function signature
-  typedef std::function<void(const cmdobj_t&)> CommandCallback;
+  typedef std::function<void(cmdmeta_t)> CommandCallback;
   CommandCallback m_command_callback = nullptr;
+
+  //! The glue between commanded and completion callback
+  void handle_command(cmdmeta_t command);
 
   //! Single thrad is responsible to trigger tasks 
   std::atomic<bool> m_active;

--- a/include/cmdlib/CommandedObject.hpp
+++ b/include/cmdlib/CommandedObject.hpp
@@ -14,7 +14,7 @@ namespace dunedaq::cmdlib {
 
 typedef nlohmann::json cmdobj_t;
 
-typedef std::map<std::string, nlohmann::json> cmdmeta_t;
+typedef std::map<std::string, std::string> cmdmeta_t;
 
 /**
  * @brief Interface needed by commanded objects in the DAQ

--- a/include/cmdlib/CommandedObject.hpp
+++ b/include/cmdlib/CommandedObject.hpp
@@ -14,6 +14,8 @@ namespace dunedaq::cmdlib {
 
 typedef nlohmann::json cmdobj_t;
 
+typedef std::map<std::string, nlohmann::json> cmdmeta_t;
+
 /**
  * @brief Interface needed by commanded objects in the DAQ
  */

--- a/include/cmdlib/CommandedObject.hpp
+++ b/include/cmdlib/CommandedObject.hpp
@@ -13,7 +13,6 @@
 namespace dunedaq::cmdlib {
 
 typedef nlohmann::json cmdobj_t;
-
 typedef std::map<std::string, std::string> cmdmeta_t;
 
 /**

--- a/plugins/stdinCommandFacility.cpp
+++ b/plugins/stdinCommandFacility.cpp
@@ -88,8 +88,8 @@ protected:
   std::string m_available_str;
 
   // Implementation of completion_handler interface
-  void completion_callback(const std::string& result) {
-    ERS_INFO("Command execution resulted with: " << result);
+  void completion_callback(cmdmeta_t& meta) {
+    ERS_INFO("Command execution resulted with: " << meta["result"]);
   }
 
 };

--- a/src/CommandFacility.cpp
+++ b/src/CommandFacility.cpp
@@ -51,7 +51,7 @@ void
 CommandFacility::handle_command(cmdmeta_t meta)
 {
   try {
-    m_commanded_object->execute(meta["command"]);
+    m_commanded_object->execute(nlohmann::json::parse(meta["command"]));
     meta["result"] = "OK";
   } catch (const ers::Issue& ei ) {
     meta["result"] = ei.what();

--- a/src/CommandFacility.cpp
+++ b/src/CommandFacility.cpp
@@ -41,7 +41,7 @@ CommandFacility::set_commanded(CommandedObject& commanded)
 }
 
 void 
-CommandFacility::executeCommand(cmdmeta_t meta)
+CommandFacility::execute_command(cmdmeta_t meta)
 {
   auto execfut = std::async(std::launch::deferred, m_command_callback, std::move(meta));
   m_completion_queue.push(std::move(execfut));
@@ -63,7 +63,7 @@ CommandFacility::handle_command(cmdmeta_t meta)
     meta["result"] = "Caught unknown exception";
     ers::error(CommandedObjectExecutionError(ERS_HERE, meta["result"]));
   }
-  completionCallback(meta);
+  completion_callback(meta);
 }
 
 void

--- a/src/CommandFacility.cpp
+++ b/src/CommandFacility.cpp
@@ -59,7 +59,7 @@ CommandFacility::handle_command(cmdmeta_t meta)
   } catch (const std::exception& exc) {
     meta["result"] = exc.what();
     ers::error(CommandedObjectExecutionError(ERS_HERE, "Caught std::exception", exc));
-  } catch (...) {
+  } catch (...) {  // NOLINT JCF Jan-27-2021 violates letter of the law but not the spirit
     meta["result"] = "Caught unknown exception";
     ers::error(CommandedObjectExecutionError(ERS_HERE, meta["result"]));
   }

--- a/src/CommandFacility.cpp
+++ b/src/CommandFacility.cpp
@@ -41,30 +41,29 @@ CommandFacility::set_commanded(CommandedObject& commanded)
 }
 
 void 
-CommandFacility::execute_command(const cmdobj_t& command)
+CommandFacility::executeCommand(cmdmeta_t meta)
 {
-  auto execfut = std::async(std::launch::deferred, m_command_callback, std::move(command));
+  auto execfut = std::async(std::launch::deferred, m_command_callback, std::move(meta));
   m_completion_queue.push(std::move(execfut));
 }
 
 void
-CommandFacility::handle_command(const cmdobj_t& command) 
+CommandFacility::handle_command(cmdmeta_t meta)
 {
-  std::string ret = "";
   try {
-    m_commanded_object->execute(command);
-    ret = "OK";
+    m_commanded_object->execute(meta["command"]);
+    meta["result"] = "OK";
   } catch (const ers::Issue& ei ) {
-    ret = ei.what();
+    meta["result"] = ei.what();
     ers::error(CommandedObjectExecutionError(ERS_HERE, "Caught ers::Issue", ei));
   } catch (const std::exception& exc) {
-    ret = exc.what();
+    meta["result"] = exc.what();
     ers::error(CommandedObjectExecutionError(ERS_HERE, "Caught std::exception", exc));
-  } catch (...) {  // NOLINT JCF Jan-27-2021 violates letter of the law but not the spirit
-    ret = "Caught unknown exception";
-    ers::error(CommandedObjectExecutionError(ERS_HERE, ret));
+  } catch (...) {
+    meta["result"] = "Caught unknown exception";
+    ers::error(CommandedObjectExecutionError(ERS_HERE, meta["result"]));
   }
-  completion_callback(ret);
+  completionCallback(meta);
 }
 
 void

--- a/test/apps/DummyCommandedObject.hpp
+++ b/test/apps/DummyCommandedObject.hpp
@@ -19,7 +19,7 @@
 class DummyCommandedObject : public dunedaq::cmdlib::CommandedObject
 {
 public:
-  void execute(const dunedaq::cmdlib::cmdobj_t command) {
+  void execute(const dunedaq::cmdlib::cmdobj_t& command) {
     if (command.dump() == "{\"asd\":true}") {
       ERS_INFO(command.dump() << " is a REALLY slow command");
       std::this_thread::sleep_for(std::chrono::seconds(5));

--- a/test/apps/DummyCommandedObject.hpp
+++ b/test/apps/DummyCommandedObject.hpp
@@ -19,7 +19,7 @@
 class DummyCommandedObject : public dunedaq::cmdlib::CommandedObject
 {
 public:
-  void execute(const dunedaq::cmdlib::cmdobj_t& command) {
+  void execute(const dunedaq::cmdlib::cmdobj_t command) {
     if (command.dump() == "{\"asd\":true}") {
       ERS_INFO(command.dump() << " is a REALLY slow command");
       std::this_thread::sleep_for(std::chrono::seconds(5));

--- a/test/plugins/dummyCommandFacility.cpp
+++ b/test/plugins/dummyCommandFacility.cpp
@@ -55,8 +55,8 @@ public:
 protected:
   typedef CommandFacility inherited;
 
-  void completion_callback(const std::string& result) {
-    ERS_INFO("Dummy handler just prints out result of cmd: " << result);
+  void completion_callback(cmdmeta_t& meta) {
+    ERS_INFO("Dummy handler just prints out result of cmd: " << meta["result"]);
   }
 
 };


### PR DESCRIPTION
Allow the passing of metadata along with the command itself, providing the information required to implement the completionCallback.