### PR TITLE
use CommandReply object instead of json

### DIFF
--- a/include/cmdlib/CommandFacility.hpp
+++ b/include/cmdlib/CommandFacility.hpp
@@ -14,6 +14,8 @@
 #include <cetlib/BasicPluginFactory.h>
 #include <cetlib/compiler_macros.h>
 
+#include "cmdlib/cmd/Nljs.hpp"
+
 #include <tbb/concurrent_queue.h>
 
 #include <future>
@@ -66,16 +68,16 @@ public:
   virtual void run(std::atomic<bool>& end_marker) = 0;
 
   //! Feed commands from the implementation.
-  void execute_command(const cmdobj_t& cmd, cmdmeta_t meta);
+  void execute_command(const cmdobj_t& cmd, cmd::CommandReply meta);
 
 protected:
   //! Must be implemented to handling the results of the commands
-  virtual void completion_callback(const cmdobj_t& cmd, cmdmeta_t& meta) = 0; 
+  virtual void completion_callback(const cmdobj_t& cmd, cmd::CommandReply& meta) = 0; 
 
 private:
 
   //! The glue between commanded and completion callback
-  void handle_command(const cmdobj_t& cmd, cmdmeta_t meta);
+  void handle_command(const cmdobj_t& cmd, cmd::CommandReply meta);
 
   void executor();
 
@@ -87,7 +89,7 @@ private:
   CompletionQueue m_completion_queue;
 
   //! Request callback function signature
-  typedef std::function<void(const cmdobj_t&, cmdmeta_t)> CommandCallback;
+  typedef std::function<void(const cmdobj_t&, cmd::CommandReply)> CommandCallback;
   CommandCallback m_command_callback = nullptr;
 
   //! Single thrad is responsible to trigger tasks 

--- a/include/cmdlib/CommandedObject.hpp
+++ b/include/cmdlib/CommandedObject.hpp
@@ -13,7 +13,6 @@
 namespace dunedaq::cmdlib {
 
 typedef nlohmann::json cmdobj_t;
-typedef nlohmann::json cmdmeta_t;
 
 /**
  * @brief Interface needed by commanded objects in the DAQ

--- a/plugins/stdinCommandFacility.cpp
+++ b/plugins/stdinCommandFacility.cpp
@@ -92,7 +92,7 @@ public:
         ers::error (CannotParseCommand(ERS_HERE, s.str()));
       } else {
         TLOG() << "Executing " << cmdid << " command...";
-        inherited::execute_command(m_available_commands[cmdid], cmdmeta_t());
+        inherited::execute_command(m_available_commands[cmdid], cmd::CommandReply());
       }
     }
     TLOG_DEBUG(1) << "Command handling stopped.";
@@ -106,11 +106,9 @@ protected:
   std::string m_available_str;
 
   // Implementation of completion_handler interface
-  void completion_callback(const cmdobj_t& cmd, cmdmeta_t& meta) {
+  void completion_callback(const cmdobj_t& cmd, cmd::CommandReply& meta) {
     cmd::Command  command = cmd.get<cmd::Command>();
-    cmd::CommandReply reply = meta.get<cmd::CommandReply>();
-
-    TLOG() << "Command " << command.id << " execution resulted with: " << reply.success << " " << reply.result;
+    TLOG() << "Command " << command.id << " execution resulted with: " << meta.success << " " << meta.result;
   }
 
 };

--- a/test/apps/test_stdin_app.cxx
+++ b/test/apps/test_stdin_app.cxx
@@ -39,7 +39,7 @@ main(int /*argc*/, char** /*argv[]*/)
 
   // Setup facility
   DummyCommandedObject obj;
-  auto fac = makeCommandFacility(std::string("stdin://sourcecode/appfwk/schema/fdpc-job.json"));
+  auto fac = makeCommandFacility(std::string("stdin://my_minidaq_config.json")); // TODO parametrize command file
   fac->set_commanded(obj);
   fac->run(run_marker);
   return 0;

--- a/test/plugins/dummyCommandFacility.cpp
+++ b/test/plugins/dummyCommandFacility.cpp
@@ -36,15 +36,15 @@ public:
       if (once) {
         // execute 10 quick commands
         for (auto i=0; i<1000; ++i) {
-          inherited::execute_command(democmd, cmdmeta_t());
+          inherited::execute_command(democmd, cmd::CommandReply());
         }
 
         // execute 1 slow command
-        inherited::execute_command(slowcmd, cmdmeta_t());
+        inherited::execute_command(slowcmd, cmd::CommandReply());
 
         // execute again 10 quick command   
         for (auto i=0; i<1000; ++i) {
-          inherited::execute_command(democmd, cmdmeta_t());
+          inherited::execute_command(democmd, cmd::CommandReply());
         }
         once = false;
       }
@@ -55,8 +55,8 @@ public:
 protected:
   typedef CommandFacility inherited;
 
-  void completion_callback(const cmdobj_t& cmd, cmdmeta_t& meta) {
-    TLOG() << "Command " << cmd << "\nexecution resulted with: " << meta["result"];
+  void completion_callback(const cmdobj_t& cmd, cmd::CommandReply& meta) {
+    TLOG() << "Command " << cmd << "\nexecution resulted with: " << meta.result;
   }
 
 };


### PR DESCRIPTION
Optional feature, avoiding (de)serializations from/to `CommandReply` from/to `json`.