### PR TITLE
added virtual destructors to a couple of classes to quiet compiler warnings

### DIFF
--- a/include/cmdlib/CommandFacility.hpp
+++ b/include/cmdlib/CommandFacility.hpp
@@ -50,7 +50,7 @@ class CommandFacility
 {
 public:
   explicit CommandFacility(std::string /*uri*/) {}
-  ~CommandFacility();
+  virtual ~CommandFacility();
   CommandFacility(const CommandFacility&) = 
     delete; ///< CommandFacility is not copy-constructible
   CommandFacility& operator=(const CommandFacility&) =

--- a/include/cmdlib/CommandedObject.hpp
+++ b/include/cmdlib/CommandedObject.hpp
@@ -22,6 +22,9 @@ class CommandedObject
 public:
   //! Pure virtual execute member
   virtual void execute(const cmdobj_t& command) = 0; 
+
+  // virtual destructor
+  virtual ~CommandedObject() = default;
 };
 
 } // namespace dunedaq::cmdlib


### PR DESCRIPTION
I noticed the warnings when compiling the `appfwk` package...