### PR TITLE
JCF: change CMakeLists.txt so that cmdlib can be spack install-ed aga…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(nlohmann_json REQUIRED)
 find_package(logging REQUIRED)
 find_package(ers REQUIRED)
 
-set(CMDLIB_DEPENDENCIES ${CETLIB} ${CETLIB_EXCEPT} ${TBB} ${TBB_IMPORTED_TARGETS} logging::logging ers::ers nlohmann_json::nlohmann_json)
+set(CMDLIB_DEPENDENCIES ${CETLIB} ${CETLIB_EXCEPT} TBB::tbb logging::logging ers::ers nlohmann_json::nlohmann_json)
 
 daq_codegen(*.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
 


### PR DESCRIPTION
…inst newer versions of intel-tbb than the current intel-tbb@2020.3