### PR TITLE
Include logging/Logging.hpp whenever ERS issues are declared, includi…

### DIFF
--- a/include/cmdlib/Issues.hpp
+++ b/include/cmdlib/Issues.hpp
@@ -10,6 +10,7 @@
 
 
 #include "ers/Issue.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 #include <string>
 
 namespace dunedaq {

--- a/include/cmdlib/Issues.hpp
+++ b/include/cmdlib/Issues.hpp
@@ -10,7 +10,7 @@
 
 
 #include "ers/Issue.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 #include <string>
 
 namespace dunedaq {

--- a/plugins/stdinCommandFacility.cpp
+++ b/plugins/stdinCommandFacility.cpp
@@ -10,7 +10,7 @@
 #include "cmdlib/Issues.hpp"
 #include "cmdlib/cmd/Nljs.hpp"
 
-#include <logging/Logging.hpp>
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 #include <nlohmann/json.hpp>
 #include <cetlib/BasicPluginFactory.h>
 

--- a/plugins/stdinCommandFacility.cpp
+++ b/plugins/stdinCommandFacility.cpp
@@ -10,7 +10,7 @@
 #include "cmdlib/Issues.hpp"
 #include "cmdlib/cmd/Nljs.hpp"
 
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 #include <nlohmann/json.hpp>
 #include <cetlib/BasicPluginFactory.h>
 

--- a/test/apps/DummyCommandedObject.hpp
+++ b/test/apps/DummyCommandedObject.hpp
@@ -11,7 +11,7 @@
 
 #include "cmdlib/CommandedObject.hpp"
 
-#include <logging/Logging.hpp>
+#include "logging/Logging.hpp"
 
 #include <stdexcept>
 #include <string>

--- a/test/apps/test_dummy_app.cxx
+++ b/test/apps/test_dummy_app.cxx
@@ -9,7 +9,7 @@
 #include "DummyCommandedObject.hpp"
 #include "cmdlib/CommandFacility.hpp"
 
-#include <logging/Logging.hpp>
+#include "logging/Logging.hpp"
 
 #include <string>
 #include <chrono>


### PR DESCRIPTION
…ng note on why (TLOG() << ERSIssue only works when Logging.hpp included first)